### PR TITLE
Keep metadata after theorems_to_expand

### DIFF
--- a/python/htps.cpp
+++ b/python/htps.cpp
@@ -1017,6 +1017,7 @@ PyObject* Theorem_NewFromShared(const std::shared_ptr<htps::theorem>& thm_ptr) {
     c_obj->hypotheses = thm->hypotheses;
     c_obj->past_tactics = thm->past_tactics;
     c_obj->py_dict = thm->py_dict;
+    Py_INCREF(c_obj->py_dict);
     return obj;
 }
 

--- a/python/htps.cpp
+++ b/python/htps.cpp
@@ -1016,8 +1016,8 @@ PyObject* Theorem_NewFromShared(const std::shared_ptr<htps::theorem>& thm_ptr) {
     c_obj->set_context(thm->context);
     c_obj->hypotheses = thm->hypotheses;
     c_obj->past_tactics = thm->past_tactics;
-    c_obj->py_dict = thm->py_dict;
-    Py_INCREF(c_obj->py_dict);
+//    c_obj->py_dict = thm->py_dict;
+//    Py_INCREF(c_obj->py_dict);
     return obj;
 }
 

--- a/python/htps.cpp
+++ b/python/htps.cpp
@@ -1016,6 +1016,7 @@ PyObject* Theorem_NewFromShared(const std::shared_ptr<htps::theorem>& thm_ptr) {
     c_obj->set_context(thm->context);
     c_obj->hypotheses = thm->hypotheses;
     c_obj->past_tactics = thm->past_tactics;
+    c_obj->py_dict = thm->py_dict;
     return obj;
 }
 

--- a/python/htps.cpp
+++ b/python/htps.cpp
@@ -1016,8 +1016,8 @@ PyObject* Theorem_NewFromShared(const std::shared_ptr<htps::theorem>& thm_ptr) {
     c_obj->set_context(thm->context);
     c_obj->hypotheses = thm->hypotheses;
     c_obj->past_tactics = thm->past_tactics;
-//    c_obj->py_dict = thm->py_dict;
-//    Py_INCREF(c_obj->py_dict);
+    Py_INCREF(c_obj->py_dict);
+    c_obj->py_dict = thm->py_dict;
     return obj;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     ],
     ext_modules=[module],
     description="Open-source implementation of HyperTree Proof Search",
-    version="0.0.2",
+    version="0.0.3",
 )

--- a/src/graph/lean.h
+++ b/src/graph/lean.h
@@ -59,6 +59,13 @@ namespace htps {
 
         lean_theorem() = default;
 
+        ~lean_theorem() {
+            past_tactics.clear();
+#ifdef PYTHON_BINDINGS
+            Py_XDECREF(py_dict);
+#endif
+        }
+
         bool operator==(const theorem &t) const override;
     };
 }

--- a/src/graph/lean.h
+++ b/src/graph/lean.h
@@ -59,12 +59,12 @@ namespace htps {
 
         lean_theorem() = default;
 
-        ~lean_theorem() {
-            past_tactics.clear();
-#ifdef PYTHON_BINDINGS
-            Py_XDECREF(py_dict);
-#endif
-        }
+//        ~lean_theorem() {
+//            past_tactics.clear();
+//#ifdef PYTHON_BINDINGS
+//            Py_XDECREF(py_dict);
+//#endif
+//        }
 
         bool operator==(const theorem &t) const override;
     };

--- a/src/graph/lean.h
+++ b/src/graph/lean.h
@@ -59,12 +59,7 @@ namespace htps {
 
         lean_theorem() = default;
 
-//        ~lean_theorem() {
-//            past_tactics.clear();
-//#ifdef PYTHON_BINDINGS
-//            Py_XDECREF(py_dict);
-//#endif
-//        }
+        ~lean_theorem() = default;
 
         bool operator==(const theorem &t) const override;
     };

--- a/tests/test_cpython.py
+++ b/tests/test_cpython.py
@@ -96,9 +96,9 @@ def test_theorem_context():
     assert theorem.unique_string == ""
     assert theorem.conclusion == ""
     assert theorem.context.namespaces == context.namespaces
-    # assert theorem.metadata == {}
-    # theorem.metadata = {"key": "value"}
-    # assert theorem.metadata == {"key": "value"}
+    assert theorem.metadata == {}
+    theorem.metadata = {"key": "value"}
+    assert theorem.metadata == {"key": "value"}
     context2 = Context(["a∧a"])
     theorem.context = context2
     assert theorem.context.namespaces == context2.namespaces
@@ -387,15 +387,15 @@ def test_htps_expansion():
     tactics = []
     theorem = Theorem("andb∧", "A", hypotheses, context, tactics)
     theorem2 = Theorem("andb∧d", "B", hypotheses, context, tactics)
-    # theorem.metadata = {"key": "value"}
+    theorem.metadata = {"key": "value"}
     params = SearchParams(0.3, PolicyType.RPO, 10, 3, True, True, True, True, 0.99, 10, True, True, True, 0.0, QValueSolved.One, 0.7, Metric.Time, NodeMask.NoMask, 1.0, 1.0, True, 1)
     search = HTPS(theorem, params)
 
     # Will find the root
     theorems = search.theorems_to_expand()
-    # assert len(theorems) == 1
-    # _compare_theorem(theorems[0], theorem)
-    # assert theorems[0].metadata == {"key": "value"}
+    assert len(theorems) == 1
+    _compare_theorem(theorems[0], theorem)
+    assert theorems[0].metadata == {"key": "value"}
 
     env_durations = [1, 1]
     log_critic = -0.5

--- a/tests/test_cpython.py
+++ b/tests/test_cpython.py
@@ -96,9 +96,9 @@ def test_theorem_context():
     assert theorem.unique_string == ""
     assert theorem.conclusion == ""
     assert theorem.context.namespaces == context.namespaces
-    assert theorem.metadata == {}
-    theorem.metadata = {"key": "value"}
-    assert theorem.metadata == {"key": "value"}
+    # assert theorem.metadata == {}
+    # theorem.metadata = {"key": "value"}
+    # assert theorem.metadata == {"key": "value"}
     context2 = Context(["a∧a"])
     theorem.context = context2
     assert theorem.context.namespaces == context2.namespaces
@@ -387,15 +387,15 @@ def test_htps_expansion():
     tactics = []
     theorem = Theorem("andb∧", "A", hypotheses, context, tactics)
     theorem2 = Theorem("andb∧d", "B", hypotheses, context, tactics)
-    theorem.metadata = {"key": "value"}
+    # theorem.metadata = {"key": "value"}
     params = SearchParams(0.3, PolicyType.RPO, 10, 3, True, True, True, True, 0.99, 10, True, True, True, 0.0, QValueSolved.One, 0.7, Metric.Time, NodeMask.NoMask, 1.0, 1.0, True, 1)
     search = HTPS(theorem, params)
 
     # Will find the root
     theorems = search.theorems_to_expand()
-    assert len(theorems) == 1
-    _compare_theorem(theorems[0], theorem)
-    assert theorems[0].metadata == {"key": "value"}
+    # assert len(theorems) == 1
+    # _compare_theorem(theorems[0], theorem)
+    # assert theorems[0].metadata == {"key": "value"}
 
     env_durations = [1, 1]
     log_critic = -0.5

--- a/tests/test_cpython.py
+++ b/tests/test_cpython.py
@@ -96,6 +96,9 @@ def test_theorem_context():
     assert theorem.unique_string == ""
     assert theorem.conclusion == ""
     assert theorem.context.namespaces == context.namespaces
+    assert theorem.metadata == {}
+    theorem.metadata = {"key": "value"}
+    assert theorem.metadata == {"key": "value"}
     context2 = Context(["a∧a"])
     theorem.context = context2
     assert theorem.context.namespaces == context2.namespaces
@@ -384,15 +387,16 @@ def test_htps_expansion():
     tactics = []
     theorem = Theorem("andb∧", "A", hypotheses, context, tactics)
     theorem2 = Theorem("andb∧d", "B", hypotheses, context, tactics)
+    theorem.metadata = {"key": "value"}
     params = SearchParams(0.3, PolicyType.RPO, 10, 3, True, True, True, True, 0.99, 10, True, True, True, 0.0, QValueSolved.One, 0.7, Metric.Time, NodeMask.NoMask, 1.0, 1.0, True, 1)
     search = HTPS(theorem, params)
-    print(theorem)
-    assert theorem.metadata == {}
-    theorem.metadata = {"key": "value"}
-    assert theorem.metadata == {"key": "value"}
-    theorem.metadata = {}
+
     # Will find the root
     theorems = search.theorems_to_expand()
+    assert len(theorems) == 1
+    _compare_theorem(theorems[0], theorem)
+    assert theorems[0].metadata == {"key": "value"}
+
     env_durations = [1, 1]
     log_critic = -0.5
     tactic_a = Tactic("dummy_tactica", True, 1)


### PR DESCRIPTION
With the old version, we were not copying the metadata reference, so the metadata got lost.
This fixes it, hopefully without messing up the references.