### PR TITLE
Kill tactic recursively

### DIFF
--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -1537,7 +1537,11 @@ namespace htps {
                 if (node.is_bad()) {
                     for (const auto &[parent_th, tactic_id]: ancestors.get_ancestors(th)) {
                         if (!parent_th.empty()) {
-                            nodes.at(parent_th)->kill_tactic(tactic_id);
+                            if (!nodes.contains(parent_th)) {
+                                std::string msg = "Parent node not found: " + parent_th;
+                                throw std::runtime_error(msg);
+                            }
+                            kill_tactic(nodes.at(parent_th), tactic_id);
                         }
                     }
                     continue;

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -1535,7 +1535,8 @@ namespace htps {
                 std::shared_ptr<T> node_ptr = std::make_shared<T>(node);
                 nodes.set(th, node_ptr);
                 if (node.is_bad()) {
-                    for (const auto &[parent_th, tactic_id]: ancestors.get_ancestors(th)) {
+                    const AncestorSet anc = ancestors.get_ancestors(th);
+                    for (const auto &[parent_th, tactic_id]: anc) {
                         if (!parent_th.empty()) {
                             if (!nodes.contains(parent_th)) {
                                 std::string msg = "Parent node not found: " + parent_th;


### PR DESCRIPTION
The call to node kill tactic did not account for recursive killing if the final tactic was killed. The method implemented directly on graph is used now, as this one includes recursive behaviour.